### PR TITLE
Fix DSEG overlap detection

### DIFF
--- a/src/directiv.c
+++ b/src/directiv.c
@@ -188,11 +188,7 @@ parse_directive(struct prog_info *pi)
 			        pi->segment->ident, pi->segment->addr, pi->list_line);
 			pi->list_line = NULL;
 		}
-		if (i > 0) {
-			fix_orglist(pi->segment);
-			advance_ip(pi->segment, i);
-			def_orglist(pi->segment);
-		}
+		advance_ip(pi->segment, i);
 		break;
 	case DIRECTIVE_CSEG:
 		fix_orglist(pi->segment);


### PR DESCRIPTION
`fix_orglist` and `fix_orglist` should not be called for .BYTE directive, as it ruins overlap detection.

This commit partially reverts 3e0d391ab7570036ddaeb38f6fe87ac718d9ffac