### PR TITLE
Yet another device.c update

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ Roland Riegel
 Peter Katzmann
 Donald D. Davis
 Virgil Dupras
+Tomek Szczęsny
 
 And all the anonymous people who submitted patches!
 

--- a/src/device.c
+++ b/src/device.c
@@ -103,15 +103,26 @@ struct device device_list[] = {
 	{  "ATmega163",        8192,      0x60,     1024,    512, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_ELPM|DF_NO_ESPM},
 	{   "ATmega16",        8192,      0x60,     1024,    512, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_ELPM|DF_NO_ESPM},
 	{  "ATmega323",       16384,      0x60,     2048,   1024, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_ELPM|DF_NO_ESPM}, // 137 - EICALL - EIJMP - ELPM(3) - ESPM = 131 (Data sheet says 130 but it's wrong)
-	{ "ATmega328P",       16384,     0x100,     2048,   1024, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_ELPM|DF_NO_ESPM},
 	{   "ATmega32",       16384,      0x60,     2048,   1024, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_ELPM|DF_NO_ESPM},
 	{  "ATmega603",       32768,      0x60,     4096,   2048, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_MUL|DF_NO_MOVW|DF_NO_LPM_X|DF_NO_ELPM|DF_NO_SPM|DF_NO_ESPM|DF_NO_BREAK},
 	{  "ATmega103",       65536,      0x60,     4096,   4096, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_MUL|DF_NO_MOVW|DF_NO_LPM_X|DF_NO_ELPM_X|DF_NO_SPM|DF_NO_ESPM|DF_NO_BREAK}, // 137 - EICALL - EIJMP - MUL(6) - MOVW - LPM_X(2) - ELPM_X(2) - SPM - ESPM - BREAK = 121
 	{  "ATmega104",       65536,      0x60,     4096,   4096, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_ESPM}, // Old name for mega128
 	{  "ATmega128",       65536,     0x100,     4096,   4096, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_ESPM}, // 137 - EICALL - EIJMP - ESPM = 134 (Data sheet says 133 but it's wrong)
+	{ "ATmega128A",       65536,     0x100,     4096,   4096, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_ESPM},
 	{   "ATmega48",        2048,     0x100,      512,    256, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_ELPM|DF_NO_ESPM},
+	{  "ATmega48A",        2048,     0x100,      512,    256, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_ELPM|DF_NO_ESPM},
+	{  "ATmega48P",        2048,     0x100,      512,    256, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_ELPM|DF_NO_ESPM},
+	{ "ATmega48PA",        2048,     0x100,      512,    256, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_ELPM|DF_NO_ESPM},
 	{   "ATmega88",        4096,     0x100,     1024,    512, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_ELPM|DF_NO_ESPM},
+	{  "ATmega88A",        4096,     0x100,     1024,    512, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_ELPM|DF_NO_ESPM},
+	{  "ATmega88P",        4096,     0x100,     1024,    512, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_ELPM|DF_NO_ESPM},
+	{ "ATmega88PA",        4096,     0x100,     1024,    512, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_ELPM|DF_NO_ESPM},
 	{  "ATmega168",        8192,     0x100,     1024,    512, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_ELPM|DF_NO_ESPM},
+	{ "ATmega168A",        8192,     0x100,     1024,    512, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_ELPM|DF_NO_ESPM},
+	{ "ATmega168P",        8192,     0x100,     1024,    512, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_ELPM|DF_NO_ESPM},
+	{"ATmega168PA",        8192,     0x100,     1024,    512, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_ELPM|DF_NO_ESPM},
+	{  "ATmega328",       16384,     0x100,     2048,   1024, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_ELPM|DF_NO_ESPM},
+	{ "ATmega328P",       16384,     0x100,     2048,   1024, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_ELPM|DF_NO_ESPM},
 	{  "ATmega644",       65536,     0x100,     4096,   2048, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_ELPM|DF_NO_ESPM},
 	{ "ATmega8515",        8192,      0x60,      512,    512, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_ELPM|DF_NO_ESPM},
 	{ "ATmega1280",       65536,     0x200,     8192,   4096, DF_NO_EICALL|DF_NO_EIJMP|DF_NO_ESPM},


### PR DESCRIPTION
I added all currently available variants of atmega 48/88/168/328, as well as atmega 128. None was deleted, I just moved one down a few lines. 