### PR TITLE
programming language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.inc linguist-language=asm
+inc/* linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 *.inc linguist-language=asm
-inc/* linguist-generated
+includes/* linguist-generated


### PR DESCRIPTION
`*.inc` were automatically categorized as Pascal, but are in fact AVR Assembly. The files in `includes/` should not contribute to the programming language statistics though, since they are generated from respective `*.xml` files.